### PR TITLE
added splay and timeout params for r10k cronjobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
+## [v6.4.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.4.0) (2022-06-30)
+
+- feat: add r10k cron job `splay`, `splayLimit` and `timeout` params
+
 ## [v6.3.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v6.3.0) (2022-06-29)
 
 - feat: add `extraContainers` to both masters and compilers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # This repository is owned by Puppet's Platform Services team and community partners
 
-* @puppetlabs/platform-services @Xtigyro @slconley @raphink @davidphay
+* @puppetlabs/platform-services @Xtigyro @slconley @raphink @davidphay @skoef

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 6.3.0
+version: 6.4.0
 appVersion: 7.4.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
@@ -26,6 +26,8 @@ maintainers:
     email: raphael.pinson@camptocamp.com
   - name: davidphay
     email: david.phayanouvong@gmail.com
+  - name: skoef
+    email: reinier@skoef.nl
   - name: Pupperware Team
     email: pupperware@puppet.com
 engine: gotpl

--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.code.resources` | r10k control repo resource limits |``|
 | `r10k.code.cronJob.enabled` | enable or disable r10k control repo cron job schedule policy | `true`|
 | `r10k.code.cronJob.schedule` | r10k control repo cron job schedule policy | `*/15 * * * *`|
+| `r10k.code.cronJob.splay` | apply random sleep before running r10k control repo cron job | `true`|
+| `r10k.code.cronJob.splayLimit` | maximum splay in seconds applied before running r10k control repo cron job | `60`|
+| `r10k.code.cronJob.timeout` | timeout in seconds to apply when running r10k control repo cron job takes too long | ``|
 | `r10k.code.cronJob.successFile` | path to file reflecting success of r10k control repo cron job | `~/.r10k_code_cronjob.success`|
 | `r10k.code.extraArgs` | r10k control repo additional container env args |``|
 | `r10k.code.extraEnv` | r10k control repo additional container env vars |``|
@@ -250,6 +253,9 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `r10k.hiera.resources` | r10k hiera data resource limits |``|
 | `r10k.hiera.cronJob.enabled` | enable or disable r10k hiera data cron job schedule policy | `true`|
 | `r10k.hiera.cronJob.schedule` | r10k hiera data cron job schedule policy | `*/2 * * * *`|
+| `r10k.hiera.cronJob.splay` | apply random sleep before running r10k hiera data cron job | `true`|
+| `r10k.hiera.cronJob.splayLimit` | maximum splay in seconds applied before running r10k hiera data cron job | `60`|
+| `r10k.hiera.cronJob.timeout` | timeout in seconds to apply when running r10k hiera data cron job takes too long | ``|
 | `r10k.hiera.cronJob.successFile` | path to file reflecting success of r10k hiera data cron job | `~/.r10k_hiera_cronjob.success`|
 | `r10k.hiera.extraArgs` | r10k hiera data additional container env args |``|
 | `r10k.hiera.extraEnv` | r10k hiera data additional container env vars |``|
@@ -398,6 +404,7 @@ kill %[job_numbers_above]
 * [Sean Conley](https://www.linkedin.com/in/seanconley/), Maintainer
 * [Raphaël Pinson](https://github.com/raphink), Maintainer
 * [David Phayanouvong](https://github.com/davidphay), Maintainer
+* [Reinier Schoof](https://github.com/skoef), Maintainer
 * [Scott Cressi](https://www.linkedin.com/in/scottcressi/), Co-Author
 * [Kai Sisterhenn](https://www.sistason.de/), Contributor
 * [chwehrli](https://github.com/chwehrli), Contributor
@@ -405,7 +412,6 @@ kill %[job_numbers_above]
 * [Hryhorii Didenko](https://github.com/HryhoriiDidenko), Contributor
 * [John Stewart](https://github.com/jstewart612), Contributor
 * [Erlon Pinheiro](https://github.com/erlonpinheiro), Contributor
-* [Reinier Schoof](https://github.com/skoef), Contributor
 * [Manasseh MMadu](https://github.com/mensaah), Contributor
 * [Aidan](https://github.com/artificial-aidan), Contributor
 * [Aurélien Le Clainche](https://www.linkedin.com/in/aurelien-le-clainche/), Contributor

--- a/templates/r10k-code.configmap.yaml
+++ b/templates/r10k-code.configmap.yaml
@@ -20,7 +20,10 @@ data:
 
   r10k_code_cronjob.sh: |
     #!/usr/bin/env sh
-    /docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
+    {{- if .Values.r10k.code.cronJob.splay }}
+    sleep $(( RANDOM % {{ int .Values.r10k.code.cronJob.splayLimit }} ))
+    {{- end }}
+    {{ with .Values.r10k.code.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_code.yaml \
     --puppetfile {{ template "r10k.code.args" . }} > ~/.r10k_code_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then

--- a/templates/r10k-hiera.configmap.yaml
+++ b/templates/r10k-hiera.configmap.yaml
@@ -25,7 +25,10 @@ data:
 
   r10k_hiera_cronjob.sh: |
     #!/usr/bin/env sh
-    /docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
+    {{- if .Values.r10k.hiera.cronJob.splay }}
+    sleep $(( RANDOM % {{ int .Values.r10k.hiera.cronJob.splayLimit }} ))
+    {{- end }}
+    {{ with .Values.r10k.hiera.cronJob.timeout }}timeout -s 9 {{ int . }} {{ end }}/docker-entrypoint.sh deploy environment --config /etc/puppetlabs/puppet/r10k_hiera.yaml \
     --puppetfile {{ template "r10k.hiera.args" . }} > ~/.r10k_hiera_cronjob.out 2>&1
     retVal=$?
     if [ "$retVal" -eq "0" ]; then

--- a/values.yaml
+++ b/values.yaml
@@ -337,6 +337,9 @@ r10k:
     cronJob:
       enabled: true
       schedule: "*/5 * * * *"
+      splay: false
+      splayLimit: 60
+      # timeout: 60
       successFile: ~/.r10k_code_cronjob.success
     ## Additional r10k code container arguments
     extraArgs: []
@@ -381,6 +384,9 @@ r10k:
     cronJob:
       enabled: true
       schedule: "*/4 * * * *"
+      splay: false
+      splayLimit: 60
+      # timeout: 60
       successFile: ~/.r10k_hiera_cronjob.success
     ## Additional r10k hiera container environment variables
     extraArgs: []


### PR DESCRIPTION
When just using the regular cron schedule, all my compilers (I have a bunch of them) all contact my git repo at the same time, which intermittently fails for either the control repo or the submodules r10k fetches for me. Applying a random sleep before each compiler tries to checkout the code lowers the risk of all the compilers running r10k at the same time. The `splay` param allows to enable applying random sleep and `splayLimit` controls the maximum amount of seconds of sleep.

Also, when multiple compilers dó checkout code at the same time, it happens that r10k hangs and becomes stale until the command is manually killed. Applying a timeout to kill the command when this happens allows the compiler to retry the next cron interval and self-heal.