### PR TITLE
fix: configure pgchecker to use external postgresql hostname if configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v7.4.4](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.4) (2023-06-27)
+- Fix: pgchecker doesn't work with external database. Added the possibility of setting external postgresql.hostname with .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME
+
 ## [v7.4.3](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v7.4.3) (2023-05-10)
 - Fix: puppet ca cronjob pvc claim name
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 7.4.3
+version: 7.4.4
 appVersion: 7.9.2
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -429,6 +429,8 @@ Return PostgreSQL host name
 {{- else }}
 {{- printf "%s-%s" .Release.Name "postgresql-primary-hl" | trimSuffix "-" -}}
 {{- end -}}
+{{- else if .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME }}
+{{- printf "%s" .Values.puppetdb.extraEnv.PUPPETDB_POSTGRES_HOSTNAME -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
This is a direct rip-off from https://github.com/puppetlabs/puppetserver-helm-chart/pull/175 with requested corrections.