### PR TITLE
Mounts puppetserver.extraSecrets into pods

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -731,6 +731,39 @@ Return puppetdb certificate name without extension
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return unique list of volumes from puppetserver.extraSecrets
+*/}}
+{{- define "puppetserver.extraSecrets.volumes" -}}
+{{- $secretList := list -}}
+{{- range $secret := .Values.puppetserver.extraSecrets -}}
+{{- if not (has $secret.name $secretList) -}}
+{{- $secretList = append $secretList $secret.name -}}
+{{- end -}}
+{{- end -}}
+{{- range $secretName := $secretList }}
+- name: {{ $secretName }}-volume
+  secret:
+    secretName: {{ $secretName }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return volumeMounts from puppetserver.extraSecrets
+*/}}
+{{- define "puppetserver.extraSecrets.volumeMounts" -}}
+{{- range $secret := .Values.puppetserver.extraSecrets }}
+- name: {{ $secret.name }}-volume
+{{- range $k, $v := $secret }}
+{{- if not (eq $k "name") }}
+  {{ $k }}: {{ $v }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+
 {{/* *************************************************************************************
 The following definitions were more complex and necessary during part of this development.
 Now they are essentially just stubs but left here in case they might be needed again soon.

--- a/templates/puppet-preInstall.job.yaml
+++ b/templates/puppet-preInstall.job.yaml
@@ -95,6 +95,7 @@ spec:
             {{- end }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
@@ -167,6 +168,7 @@ spec:
               mountPath: /crl
             {{- end }}
             {{- end }}
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
           {{- if .Values.global.runAsNonRoot }}
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
@@ -225,6 +227,7 @@ spec:
               mountPath: /crl
             {{- end }}
             {{- end }}
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
           {{- if .Values.global.runAsNonRoot }}
           securityContext:
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
@@ -299,6 +302,7 @@ spec:
               mountPath: /docker-custom-entrypoint.d/{{ $key }}
               subPath: {{ $key }}
             {{- end }}
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
@@ -368,11 +372,7 @@ spec:
             secretName: {{ template "puppetserver.hiera.privateSecret" . }}
         {{- end }}
         {{- end }}
-        {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
-        - name: {{ $extraSecret.name }}
-          secret:
-            secretName: {{ $extraSecret.name }}
-        {{- end }}
+        {{- include "puppetserver.extraSecrets.volumes" . | nindent 8 }}
         {{- if or .Values.puppetserver.preGeneratedCertsJob.enabled .Values.singleCA.enabled }}
         - name: puppetserver-certs
         {{- if not .Values.singleCA.enabled }}

--- a/templates/puppet-r10k-deployment.yaml
+++ b/templates/puppet-r10k-deployment.yaml
@@ -99,6 +99,7 @@ spec:
           - name: r10k-code-volume
             mountPath: /etc/puppetlabs/puppet/r10k_code.yaml
             subPath: r10k_code.yaml
+          {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 10 }}
           readinessProbe:
             exec:
               command:
@@ -176,6 +177,7 @@ spec:
               mountPath: /etc/puppetlabs/puppet/eyaml/keys/private_key.pkcs7.pem
               subPath: private_key.pkcs7.pem
             {{- end }}
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
           readinessProbe:
             exec:
               command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.hiera.cronJob.successFile }}"]
@@ -271,9 +273,5 @@ spec:
             name: {{ .Values.hiera.eyaml.existingMap }}
         {{- end }}
         {{- end }}
-        {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
-        - name: {{ $extraSecret.name }}
-          secret:
-            secretName: {{ $extraSecret.name }}
-        {{- end }}
+        {{- include "puppetserver.extraSecrets.volumes" . | nindent 8 }}
 {{- end }}

--- a/templates/puppetserver-deployment-compilers.yaml
+++ b/templates/puppetserver-deployment-compilers.yaml
@@ -196,6 +196,7 @@ spec:
             {{- end }}
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
       {{- end }}
       containers:
         - name: {{ template "puppetserver.fullname" . }}
@@ -305,6 +306,7 @@ spec:
               mountPath: /etc/puppetlabs/puppet/eyaml/keys
             {{- end }}
             {{- end }}
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
           securityContext:
             {{- if .Values.global.runAsNonRoot }}
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
@@ -380,7 +382,7 @@ spec:
             mountPath: /etc/puppetlabs/code/
           - name: puppet-puppet-storage
             mountPath: /etc/puppetlabs/puppet/
-
+          {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 10 }}
           readinessProbe:
             exec:
               command:
@@ -440,6 +442,7 @@ spec:
             mountPath: /etc/puppetlabs/code/
           - name: puppet-puppet-storage
             mountPath: /etc/puppetlabs/puppet/
+          {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 10 }}
           readinessProbe:
             exec: 
               command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.hiera.cronJob.successFile }}"]
@@ -690,11 +693,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.confd.claimName" . }}
         {{- end }}
-        {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
-        - name: {{ $extraSecret.name }}
-          secret:
-            secretName: {{ $extraSecret.name }}
-        {{- end }}
+        {{- include "puppetserver.extraSecrets.volumes" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 10 }}

--- a/templates/puppetserver-deployment-masters.yaml
+++ b/templates/puppetserver-deployment-masters.yaml
@@ -219,6 +219,7 @@ spec:
               subPath: site.pp
             - name: puppet-serverdata-storage
               mountPath: /opt/puppetlabs/server/data/puppetserver/
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
       {{- end }}
       containers:
         - name: {{ template "puppetserver.fullname" . }}
@@ -328,6 +329,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 12 }}
           securityContext:
             {{- if .Values.global.runAsNonRoot }}
             runAsUser: {{ .Values.global.securityContext.runAsUser }}
@@ -412,6 +414,7 @@ spec:
           - name: r10k-code-volume
             mountPath: /etc/puppetlabs/puppet/r10k_code.yaml
             subPath: r10k_code.yaml
+          {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 10 }}
           readinessProbe:
             exec:
               command:
@@ -471,6 +474,7 @@ spec:
             mountPath: /etc/puppetlabs/code/
           - name: puppet-puppet-storage
             mountPath: /etc/puppetlabs/puppet/
+          {{- include "puppetserver.extraSecrets.volumeMounts" . | nindent 10 }}
           readinessProbe:
             exec:
               command: ["/bin/sh", "-ec", "test -f {{ .Values.r10k.hiera.cronJob.successFile }}"]
@@ -733,11 +737,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "puppetserver.persistence.confd.claimName" . }}
         {{- end }}
-        {{- range $extraSecret := .Values.puppetserver.extraSecrets }}
-        - name: {{ $extraSecret.name }}
-          secret:
-            secretName: {{ $extraSecret.name }}
-        {{- end }}
+        {{- include "puppetserver.extraSecrets.volumes" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -573,7 +573,7 @@ puppetserver:
   ##   - name: myBigSecret
   ##     mountPath: /custom/path/secret
   ##     readOnly: true
-  ##     
+  ##
   extraSecrets: []
 
   ## Optional init arguments

--- a/values.yaml
+++ b/values.yaml
@@ -565,8 +565,15 @@ puppetserver:
     #    #!/bin/sh
     #    echo hi
 
-  ## Optional Secrets to mount in puppetserver container
+  ## Optional Secrets to mount in puppetserver container. Each secret is defined by its desired
+  ##   volumeMounts properties
   ##
+  ## Sample:
+  ## extraSecrets:
+  ##   - name: myBigSecret
+  ##     mountPath: /custom/path/secret
+  ##     readOnly: true
+  ##     
   extraSecrets: []
 
   ## Optional init arguments


### PR DESCRIPTION
Solves #166 and #192

Now `puppetserver.extraSecrets` must be a list of secret volumeMounts specifications like this:

```yaml
extraSecrets:
  - name: myBigSecret
    mountPath: /custom/path/secret
    readOnly: true
  - name: myOtherBigSecret
    mountPath: /custom/other/key
    subPath: key
  - name: myOtherBigSecret
    mountPath: /custom/other/cert
    subPath: cert
```

That configuration creates two volumes in each pod: `myBigSecret-volume` and `myOtherBigSecret-volume` and three volumeMounts using the configuration specified in each `extraSecrets` items. The secrets referenced in `name` must exist in the namespace.

In #192 we discussed about a simpler implementation, but doing it like that supposed that we could not use extra configuration for the volumeMounts (e.g. `subPath`).

I open this as a draft PR because when I generate the manifests the new volumes an volumeMounts generate an extra blank line which I'm not able to get rid of. Could some of you please test it and help me with that blank lline?

Thanks in advance for your help