### PR TITLE
Allow specifying dns_alt_names for puppetdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+## [v9.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2024-06-18)
+- Fix: #233 - Allow puppetdb.fqdns.alternateServerNames to be configured
 
 ## [v9.5.1](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.1) (2024-05-09)
 - Fix: #228 - fixed check for puppet certs in a multimaster setup

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: puppetserver
-version: 9.5.1
+version: 9.5.2
 appVersion: 7.17.0
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]

--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetdb.extraEnv` | puppetdb additional container env vars |``|
 | `puppetdb.extraEnvSecret` | puppetdb additional container env vars from pre-existing secret |``|
 | `puppetdb.extraLabels` | puppetdb additional labels |``|
+| `puppetdb.fqdns.alternateServerNames` | puppetdb alternate fqdns |``|
 | `puppetdb.service.type` | define `spec.type` for the puppetdb service |`ClusterIP`|
 | `puppetdb.service.annotations` | puppetdb service annotations |``|
 | `puppetdb.service.labels` | puppetdb service labels |``|
@@ -598,3 +599,4 @@ kill %[job_numbers_above]
 * [Ben Feld](https://github.com/rootshellz), Contributor
 * [Julien Godin](https://github.com/JGodin-C2C), Contributor
 * [Diego Abelenda](https://github.com/dabelenda), Contributor
+* [Johann Agnarsson](https://github.com/johannagnarsson), Contributor

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -691,6 +691,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Define puppetdb alternate SAN
+*/}}
+{{- define "puppetdb.san" -}}
+{{- $san := printf "puppetdb,%s" ( include "puppetdb.fullname" . ) -}}
+{{- if .Values.puppetdb.fqdns.alternateServerNames -}}
+{{- $san = print $san "," .Values.puppetdb.fqdns.alternateServerNames -}}
+{{- end -}}
+{{- printf "%s" $san -}}
+{{- end -}}
+
+{{/*
 Define puppetdb service Account name
 */}}
 {{- define "puppetdb.serviceAccountName" -}}

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - name: PUPPETSERVER_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: DNS_ALT_NAMES
-              value: {{ template "puppetdb.fullname" . }}
++              value: {{ template "puppetdb.san" . }}
             {{- if not (hasKey .Values.puppetdb.extraEnv "PUPPETDB_POSTGRES_HOSTNAME") }}
             - name: PUPPETDB_POSTGRES_HOSTNAME
               value: "{{ include "postgresql.hostname" . }}"

--- a/templates/puppetdb-deployment.yaml
+++ b/templates/puppetdb-deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - name: PUPPETSERVER_PORT
               value: "{{ template "puppetserver.puppetserver-masters.port" . }}"
             - name: DNS_ALT_NAMES
-+              value: {{ template "puppetdb.san" . }}
+              value: {{ template "puppetdb.san" . }}
             {{- if not (hasKey .Values.puppetdb.extraEnv "PUPPETDB_POSTGRES_HOSTNAME") }}
             - name: PUPPETDB_POSTGRES_HOSTNAME
               value: "{{ include "postgresql.hostname" . }}"

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -31,7 +31,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.5.1
+            helm.sh/chart: puppetserver-9.5.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -32,7 +32,7 @@ manifest should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
             app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.5.1
+            helm.sh/chart: puppetserver-9.5.2
         spec:
           containers:
             - env:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -9,7 +9,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -10,7 +10,7 @@ manifest should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
         app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.1
+        helm.sh/chart: puppetserver-9.5.2
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/values.yaml
+++ b/values.yaml
@@ -883,6 +883,11 @@ puppetdb:
   psp:
     create: false
     annotations:
+  ## Additional fully qualified domain names (FQDN's) to add 
+  ## to the PuppetDB certificates.
+  fqdns:
+    alternateServerNames: ""   # Comma-separated
+
 
 ## PostgreSQL Sub-Chart Configuration
 ## Please check: https://github.com/bitnami/charts/tree/master/bitnami/postgresql

--- a/values.yaml
+++ b/values.yaml
@@ -883,7 +883,7 @@ puppetdb:
   psp:
     create: false
     annotations:
-  ## Additional fully qualified domain names (FQDN's) to add 
+  ## Additional fully qualified domain names (FQDN's) to add
   ## to the PuppetDB certificates.
   fqdns:
     alternateServerNames: ""   # Comma-separated


### PR DESCRIPTION
This PR allows specifying additional dns_alt_names for puppetdb container.

This resolves #233.