### PR TITLE
updating containers and enabling restic support for azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
 
-## [v9.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2024-06-18)
+## [v9.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2025-01-14)
 - Feat: #191 enable use of secret for restic environment variables
 - Feat: enable use of Azure Blob Storage including AKS Workload Identity for Restic Backups
 - Fix: Update Restic Container to v0.17.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Fix: Update curl, busybox container versions for security patches
 - Fix: #210 Readme updates for Puppet 8 upgrade
 - Fix: Readme updates for Backup instructions
+- Fix: #240 Readme updates to match corrected versions and container image locations
 
 ## [v9.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2024-06-18)
 - Fix: #233 - Allow puppetdb.fqdns.alternateServerNames to be configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ NOTE: The change log until version `v0.2.4` is auto-generated.
 - Fix: #210 Readme updates for Puppet 8 upgrade
 - Fix: Readme updates for Backup instructions
 - Fix: #240 Readme updates to match corrected versions and container image locations
+- Fix: #235, #236 Cosmetic typo about singleCA.enable
 
 ## [v9.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2024-06-18)
 - Fix: #233 - Allow puppetdb.fqdns.alternateServerNames to be configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ This file documents all notable changes to Puppet Server Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version `v0.2.4` is auto-generated.
+
+## [v9.6.0](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2024-06-18)
+- Feat: #191 enable use of secret for restic environment variables
+- Feat: enable use of Azure Blob Storage including AKS Workload Identity for Restic Backups
+- Fix: Update Restic Container to v0.17.3
+- Fix: Update PuppetBoard container to v6.0.0
+- Fix: Update PuppetServer reference to new URL due to deprecating old location and new version schema - v7.17.3-main
+- Fix: Update PuppetDB reference to new URL due to deprecating old location and new version schema - v7.20.0-main
+- Fix: Update curl, busybox container versions for security patches
+- Fix: #210 Readme updates for Puppet 8 upgrade
+- Fix: Readme updates for Backup instructions
+
 ## [v9.5.2](https://github.com/puppetlabs/puppetserver-helm-chart/tree/v9.5.2) (2024-06-18)
 - Fix: #233 - Allow puppetdb.fqdns.alternateServerNames to be configured
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: puppetserver
-version: 9.5.2
-appVersion: 7.17.0
+version: 9.6.0
+appVersion: 7.17.3
 description: Puppet automates the delivery and operation of software.
 keywords: ["puppet", "puppetserver", "automation", "iac", "infrastructure", "cm", "ci", "cd"]
 home: https://puppet.com/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you prefer not to auto-sign or manually sign the Puppet Agents' CSRs - you ca
 ## Using Single CA
 
 If you prefer, you can use a single externally issued CA - <https://puppet.com/docs/puppet/7/config_ssl_external_ca.html>.
-Enable it with `.Values.singleCA.enable`, add the crl.pem url with `.Values.singleCA.crl.url`.
+Enable it with `.Values.singleCA.enabled`, add the crl.pem url with `.Values.singleCA.crl.url`.
 
 Generate puppet & puppetdb secret (must be name `puppet.pem` & `puppetdb.pem`):
 ```

--- a/README.md
+++ b/README.md
@@ -257,11 +257,11 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | --------- | ----------- | -------|
 | `global.runAsNonRoot`| run puppetserver as non root |`false`|
 | `global.curl.image`| curl image |`curlimages/curl`|
-| `global.curl.tag`| curl image tag |`7.87.0`|
+| `global.curl.tag`| curl image tag |`8.11.1`|
 | `global.curl.imagePullPolicy`| curl image pull policy |`IfNotPresent`|
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | [] |
 | `global.pgchecker.image`| pgchecker image |`docker.io/busybox`|
-| `global.pgchecker.tag`| pgchecker image tag |`1.36`|
+| `global.pgchecker.tag`| pgchecker image tag |`1.37`|
 | `global.pgchecker.imagePullPolicy`| pgchecker image pull policy |`IfNotPresent`|
 | `global.puppetdbexporter.image`| puppetdb exporter image |`camptocamp/prometheus-puppetdb-exporter`|
 | `global.puppetdbexporter.tag`| puppetdb exporter image tag |`1.1.0`|
@@ -276,8 +276,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `global.extraEnv.*`| add extra environment variables to all containers |``|
 | `global.extraEnvSecret`| add extra environment variables to all containers from pre-existing secret |``|
 | `puppetserver.name` | puppetserver component label | `puppetserver`|
-| `puppetserver.image` | puppetserver image | `voxpupuli/container-puppetserver`|
-| `puppetserver.tag` | puppetserver img tag | `7.17.0-v1.5.0`|
+| `puppetserver.image` | puppetserver image | `ghcr.io/voxpupuli/puppetserver`|
+| `puppetserver.tag` | puppetserver img tag | `7.17.3-main`|
 | `puppetserver.pullPolicy` | puppetserver img pull policy | `IfNotPresent`|
 | `puppetserver.persistence.data.enabled`| Persists /opt/puppetlabs/server/data/puppetserver/ in a PVC |`true`|
 | `puppetserver.persistence.data.existingClaim`| If non-empty, use a pre-defined PVC for puppet data |``|
@@ -360,7 +360,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.masters.backup.successfulJobsHistoryLimit` | puppetserver restic backup CronJob successfulJobsHistoryLimit | `2`|
 | `puppetserver.masters.backup.schedule` | puppetserver restic backup CronJob schedule | `@every 12h`|
 | `puppetserver.masters.backup.image` | puppetserver restic backup CronJob image | `restic/restic`|
-| `puppetserver.masters.backup.tag` | puppetserver restic backup CronJob image tag | `0.13.1`|
+| `puppetserver.masters.backup.tag` | puppetserver restic backup CronJob image tag | `0.17.3`|
 | `puppetserver.masters.backup.pullPolicy` | puppetserver restic backup CronJob image pullPolicy | `IfNotPresent`|
 | `puppetserver.masters.backup.caConfigMap` | puppetserver restic backup CronJob configmap for custom ca-certificates.crt | ``|
 | `puppetserver.masters.backup.serviceAccount.enabled` | puppetserver backup serviceaccount enabled, useful for setting up AKS workload identity, will not be created unless creat also true | `false`|
@@ -483,8 +483,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `postgresql.networkPolicy.enabled` | enable `networkPolicy` on  postgresql | `true`|
 | `puppetdb.enabled` | puppetdb component enabled |`true`|
 | `puppetdb.name` | puppetdb component label | `puppetdb`|
-| `puppetdb.image` | puppetdb img | `voxpupuli/container-puppetdb`|
-| `puppetdb.tag` | puppetdb img tag | `7.18.0-v1.5.0`|
+| `puppetdb.image` | puppetdb img | `voxpupuli/puppetdb`|
+| `puppetdb.tag` | puppetdb img tag | `7.20.0-main`|
 | `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`|
 | `puppetdb.resources` | puppetdb resource limits |``|
 | `puppetdb.extraEnv` | puppetdb additional container env vars |``|
@@ -513,8 +513,8 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetdb.psp.create`| Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later |`false`|
 | `puppetboard.enabled` | puppetboard availability | `false`|
 | `puppetboard.name` | puppetboard component label | `puppetboard`|
-| `puppetboard.image` | puppetboard img | `xtigyro/puppetboard`|
-| `puppetboard.tag` | puppetboard img tag | `2.1.2`|
+| `puppetboard.image` | puppetboard img | `ghcr.io/voxpupuli/puppetboard`|
+| `puppetboard.tag` | puppetboard img tag | `6.0.0`|
 | `puppetboard.port` | puppetboard container port | `9090`|
 | `puppetboard.pullPolicy` | puppetboard img pull policy | `IfNotPresent`|
 | `puppetboard.resources` | puppetboard resource limits |``|

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ backup:
 
 Alternatively you can define `puppetserver.masters.backup.restic.repository` and `puppetserver.masters.backup.restic.existingSecret` to use a pre-configured (NOTE: this chart will not provision the secret if defined) e.g.:
 
-
 ```
 backup:
   enabled: true

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `postgresql.networkPolicy.enabled` | enable `networkPolicy` on  postgresql | `true`|
 | `puppetdb.enabled` | puppetdb component enabled |`true`|
 | `puppetdb.name` | puppetdb component label | `puppetdb`|
-| `puppetdb.image` | puppetdb img | `voxpupuli/puppetdb`|
+| `puppetdb.image` | puppetdb img | `ghcr.io/voxpupuli/puppetdb`|
 | `puppetdb.tag` | puppetdb img tag | `7.20.0-main`|
 | `puppetdb.pullPolicy` | puppetdb img pull policy | `IfNotPresent`|
 | `puppetdb.resources` | puppetdb resource limits |``|

--- a/README.md
+++ b/README.md
@@ -125,13 +125,7 @@ backup:
     existingSecret: restic-env
 ```
 
-a compatible secret can be created e.g.
-
-```
-kubectl create secret generic restic-env --from-literal=AWS_ACCESS_KEY_ID='ACCESSKEYHERE' --from-literal=AWS_SECRET_ACCESS_KEY='SECRETACCESSHERE' --from-literal=RESTIC_PASSWORD='ENCRYPTIONPASSWORDHERE'
-```
-
-and the configuration will be equivalent to the original config.
+The secret needs to contain `KEY=VALUE` pairs that match up with the supported Restic environment variable names. Consult the [Restic Documentation](https://restic.readthedocs.io/en/stable/index.html) for more detail on the various configuration/authentication options.
 
 The benefit of this approach is that any Compatible Restic environment variables can be configured via this method and you can in theory use any supported restic backend for backup. for example, Azure Blob storage can be used with the following config:
 
@@ -150,14 +144,6 @@ masters:
       repository: "azure:<container-name>:/"
       existingSecret: restic-env
 ```
-
-with the following secret configuration 
-
-```
-kubectl create secret generic restic-env --from-literal=AZURE_ACCOUNT_NAME='<azure storage account name>' --from-literal=RESTIC_PASSWORD='ENCRYPTIONPASSWORDHERE'
-```
-  
-Consult the [Restic Documentation](https://restic.readthedocs.io/en/stable/index.html) for more configuration/authentication options
 
 ## Chart Components
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The following table lists the configurable parameters of the Puppetserver chart 
 | `puppetserver.masters.backup.tag` | puppetserver restic backup CronJob image tag | `0.17.3`|
 | `puppetserver.masters.backup.pullPolicy` | puppetserver restic backup CronJob image pullPolicy | `IfNotPresent`|
 | `puppetserver.masters.backup.caConfigMap` | puppetserver restic backup CronJob configmap for custom ca-certificates.crt | ``|
-| `puppetserver.masters.backup.serviceAccount.enabled` | puppetserver backup serviceaccount enabled, useful for setting up AKS workload identity, will not be created unless creat also true | `false`|
+| `puppetserver.masters.backup.serviceAccount.enabled` | puppetserver backup serviceaccount enabled, useful for setting up AKS workload identity, will not be created unless create also true | `false`|
 | `puppetserver.masters.backup.serviceAccount.create` | puppetserver backup serviceaccount create, useful for setting up AKS workload identity defaults to false | `false`|
 | `puppetserver.masters.backup.serviceAccount.annotations` | puppetserver backup service account annotations, e.g. to set client-id for AKS Workload Identity | ``|
 | `puppetserver.masters.backup.restic.keep_last` | puppetserver restic backup CronJob keep last n days | `90`|

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -529,6 +529,7 @@ Create the name for the PuppetDB password secret.
 {{- end -}}
 {{- end -}}
 
+
 {{/*
 Create the name for the PuppetDB Persistent Volume Claim.
 */}}
@@ -562,6 +563,24 @@ Create the storageClassName for the PuppetDB Persistent Volume Claim.
 {{- else -}}
   {{- .Values.storage.storageClass -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the restic password secret.
+*/}}
+{{- define "restic.secret" -}}
+{{- if .Values.puppetserver.masters.backup.restic.existingSecret -}}
+  {{- .Values.puppetserver.masters.backup.restic.existingSecret -}}
+{{- else -}}
+  {{ template "puppetserver.fullname" . }}-restic-backup-creds
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define backup service Account name
+*/}}
+{{- define "backup.serviceAccountName" -}}
+  {{ template "puppetserver.fullname" . }}-restic-sa
 {{- end -}}
 
 {{/*

--- a/templates/puppetserver-ca-backup-cronjob.yaml
+++ b/templates/puppetserver-ca-backup-cronjob.yaml
@@ -23,7 +23,16 @@ spec:
         {{- end }}
     spec:
       template:
+        metadata:
+          labels:
+            {{- include "puppetserver.puppetserver.labels" . | nindent 12 }}
+            {{- with .Values.puppetserver.masters.extraLabels -}}
+            {{ toYaml . | nindent 12 }}
+            {{- end }}
         spec:
+          {{- if .Values.puppetserver.masters.backup.serviceAccount.enabled }}
+          serviceAccountName: {{ template "backup.serviceAccountName" . }}
+          {{- end }}
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
@@ -49,21 +58,27 @@ spec:
             env:
             - name: RESTIC_REPOSITORY
               value: {{ .Values.puppetserver.masters.backup.restic.repository | quote }}
+            {{- if not .Values.puppetserver.masters.backup.restic.existingSecret }}
             - name: RESTIC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "puppetserver.fullname" . }}-restic-backup-creds
+                  name: {{ template "restic.secret" . }}
                   key: restic_password
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "puppetserver.fullname" . }}-restic-backup-creds
+                  name: {{ template "restic.secret" . }}
                   key: access_key_id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "puppetserver.fullname" . }}-restic-backup-creds
+                  name: {{ template "restic.secret" . }}
                   key: secret_access_key
+            {{- else }}
+            envFrom:
+            - secretRef:
+                name: {{ .Values.puppetserver.masters.backup.restic.existingSecret }}
+            {{- end }}
             volumeMounts:
             - name: puppet-ca-storage
               mountPath: /backup/etc/puppetlabs/puppetserver/ca/

--- a/templates/puppetserver-ca-backup-secret.yaml
+++ b/templates/puppetserver-ca-backup-secret.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.puppetserver.masters.backup.enabled (not .Values.singleCA.enabled) }}
+{{- if not .Values.puppetserver.masters.backup.restic.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "puppetserver.fullname" . }}-restic-backup-creds
+  name: {{ template "restic.secret" . }}
   labels:
     {{- include "puppetserver.puppetserver.labels" . | nindent 4 }}
     {{- with .Values.puppetserver.masters.extraLabels }}
@@ -21,4 +22,5 @@ data:
   secret_access_key: {{ .secret_access_key | b64enc | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/puppetserver-ca-backup-serviceaccount.yaml
+++ b/templates/puppetserver-ca-backup-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and (.Values.puppetserver.masters.backup.serviceAccount.enabled) (.Values.puppetserver.masters.backup.serviceAccount.create) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "backup.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- with .Values.puppetserver.masters.backup.serviceAccount.annotations -}}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/jmx-servicemonitor_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
         release: kube-prometheus-stack
       name: puppetserver-jmx
       namespace: puppet

--- a/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-pvc_test.yaml.snap
@@ -9,8 +9,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-puppetdb-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb-servicemonitor_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
         release: kube-prometheus-stack
       name: puppetserver-puppetdb
       namespace: puppet

--- a/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetdb.networkpolicy_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-puppetdb
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-ca-pvc_test.yaml.snap
@@ -9,8 +9,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-ca-claim
     spec:
       accessModes:

--- a/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.deployment_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-puppetserver-compiler
     spec:
       replicas: 1
@@ -30,8 +30,8 @@ manifest should match snapshot:
             app.kubernetes.io/instance: puppetserver
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
-            app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.5.2
+            app.kubernetes.io/version: 7.17.3
+            helm.sh/chart: puppetserver-9.6.0
         spec:
           containers:
             - env:
@@ -50,7 +50,7 @@ manifest should match snapshot:
                 - name: CA_MASTERPORT
                   value: "8140"
               envFrom: null
-              image: ghcr.io/voxpupuli/container-puppetserver:7.17.0-v1.5.0
+              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -114,7 +114,7 @@ manifest should match snapshot:
                 - -c
               env: null
               envFrom: null
-              image: ghcr.io/voxpupuli/container-puppetserver:7.17.0-v1.5.0
+              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
               imagePullPolicy: IfNotPresent
               name: perms-and-dirs
               resources:

--- a/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.networkpolicy_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-puppetserver-compilers
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.pdb_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-compilers
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-compilers.statefulset_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-puppetserver-compiler
     spec:
       podManagementPolicy: OrderedReady
@@ -31,8 +31,8 @@ manifest should match snapshot:
             app.kubernetes.io/instance: puppetserver
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: puppetserver
-            app.kubernetes.io/version: 7.17.0
-            helm.sh/chart: puppetserver-9.5.2
+            app.kubernetes.io/version: 7.17.3
+            helm.sh/chart: puppetserver-9.6.0
         spec:
           containers:
             - env:
@@ -53,7 +53,7 @@ manifest should match snapshot:
                 - name: CA_MASTERPORT
                   value: "8140"
               envFrom: null
-              image: ghcr.io/voxpupuli/container-puppetserver:7.17.0-v1.5.0
+              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -112,7 +112,7 @@ manifest should match snapshot:
                 - -c
               env: null
               envFrom: null
-              image: ghcr.io/voxpupuli/container-puppetserver:7.17.0-v1.5.0
+              image: ghcr.io/voxpupuli/puppetserver:7.17.3-main
               imagePullPolicy: IfNotPresent
               name: perms-and-dirs
               resources:

--- a/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.networkpolicy_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-puppetserver
     spec:
       egress:

--- a/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-masters.pdb_test.yaml.snap
@@ -8,8 +8,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-masters
     spec:
       maxUnavailable: 2

--- a/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
+++ b/tests/__snapshot__/puppetserver-pvc_test.yaml.snap
@@ -9,8 +9,8 @@ manifest should match snapshot:
         app.kubernetes.io/instance: puppetserver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: puppetserver
-        app.kubernetes.io/version: 7.17.0
-        helm.sh/chart: puppetserver-9.5.2
+        app.kubernetes.io/version: 7.17.3
+        helm.sh/chart: puppetserver-9.6.0
       name: puppetserver-puppet-claim
     spec:
       accessModes:

--- a/values.yaml
+++ b/values.yaml
@@ -377,7 +377,7 @@ puppetserver:
       serviceAccount:
         enabled: false
         create: false
-        annotations:
+        annotations: {}
 
       ## Restric configuration
       ##

--- a/values.yaml
+++ b/values.yaml
@@ -12,16 +12,17 @@ global:
 
   curl:
     image: curlimages/curl
-    tag: 8.7.1
+    tag: 8.11.1
     imagePullPolicy: IfNotPresent
 
   r10k:
     image: puppet/r10k
     tag: 3.15.2
     imagePullPolicy: IfNotPresent
+  
   pgchecker:
     image: docker.io/busybox
-    tag: 1.36
+    tag: 1.37
     imagePullPolicy: IfNotPresent
 
   puppetdbexporter:
@@ -62,8 +63,8 @@ global:
 ##
 puppetserver:
   name: puppetserver
-  image: ghcr.io/voxpupuli/container-puppetserver
-  tag: 7.17.0-v1.5.0
+  image: ghcr.io/voxpupuli/puppetserver
+  tag: 7.17.3-main
   pullPolicy: IfNotPresent
 
   ## Configure persistence for Puppet Server
@@ -365,18 +366,25 @@ puppetserver:
 
       schedule: "@every 12h"
       image: restic/restic
-      tag: 0.13.1
+      tag: 0.17.3
       pullPolicy: IfNotPresent
 
       ## Replace ca-certificates.crt with your own CA bundle if needed
       ##
       caConfigMap: ""
+      
+      #ServiceAccount configuration - needed of using AKS Workload Identity default off to not change default
+      serviceAccount:
+        enabled: false
+        create: false
+        annotations:
 
       ## Restric configuration
       ##
       restic:
         keep_last: 90  # days
         repository: ""  # "s3:https://s3.minio.xx/backups/"
+        existingSecret: "" # to use this instead of the below
         access_key_id: ""  # s3 access key
         secret_access_key: ""  # s3 secret access key
         password: ""  # restic encryption password
@@ -757,8 +765,8 @@ r10k:
 puppetdb:
   enabled: true
   name: puppetdb
-  image: ghcr.io/voxpupuli/container-puppetdb
-  tag: 7.18.0-v1.5.0
+  image: voxpupuli/puppetdb
+  tag: 7.20.0-main
   pullPolicy: IfNotPresent
   resources: {}
   #  requests:
@@ -922,7 +930,7 @@ puppetboard:
   enabled: false
   name: puppetboard
   image: ghcr.io/voxpupuli/puppetboard
-  tag: 5.4.0
+  tag: 6.0.0
   port: 9090
   pullPolicy: IfNotPresent
   service:

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ global:
     image: puppet/r10k
     tag: 3.15.2
     imagePullPolicy: IfNotPresent
-  
+
   pgchecker:
     image: docker.io/busybox
     tag: 1.37
@@ -372,8 +372,8 @@ puppetserver:
       ## Replace ca-certificates.crt with your own CA bundle if needed
       ##
       caConfigMap: ""
-      
-      #ServiceAccount configuration - needed of using AKS Workload Identity default off to not change default
+
+      ## ServiceAccount configuration - needed of using AKS Workload Identity default off to not change default
       serviceAccount:
         enabled: false
         create: false
@@ -384,7 +384,7 @@ puppetserver:
       restic:
         keep_last: 90  # days
         repository: ""  # "s3:https://s3.minio.xx/backups/"
-        existingSecret: "" # to use this instead of the below
+        existingSecret: ""  # to use this instead of the below
         access_key_id: ""  # s3 access key
         secret_access_key: ""  # s3 secret access key
         password: ""  # restic encryption password


### PR DESCRIPTION
Pulling the list of changes from CHANGELOG

- Feat: #191 enable use of secret for restic environment variables
- Feat: enable use of Azure Blob Storage including AKS Workload Identity for Restic Backups
- Fix: Update Restic Container to v0.17.3
- Fix: Update PuppetBoard container to v6.0.0
- Fix: Update PuppetServer reference to new URL due to deprecating old location and new version schema - v7.17.3-main
- Fix: Update PuppetDB reference to new URL due to deprecating old location and new version schema - v7.20.0-main
- Fix: Update curl, busybox container versions for security patches
- Fix: #210 Readme updates for Puppet 8 upgrade
- Fix: Readme updates for Backup instructions
- Fix: #240 Readme updates to match corrected versions and container image locations
- Fix: #235, #236 Cosmetic typo about singleCA.enables

the various updates should be self explanatory but to specifically point out the changing container URL and version format for puppetserver/puppetdb as VoxPupuli are deprecating the old container URL in 2025-02

Restic now supports defining an existingSecret (but the chart will not provision it if you do) so that you can securely define the access parameters in a secret going forwards rather than Helm Chart values, the old method still works today (for S3 buckets only!), README is updated to show this with examples

Restic now also supports Azure Workload Identity and Azure Blob storage for backup repo, readme is updated to show an example but configuring workload identity e.g. the configuration of a managed identity and assigning permissions is not detailed in the readme

I have also made some additional notes in the readme to talk about upgrading puppet to v8 as well as clarify the previous notes related to updating the Helm Chart version to avoid confusion

In theory (but untested) the new existingSecret method for restic config allows a user to set *any* compatible environment value for restic and could therefore support additional backend repos, I have only tested Azure Blob Storage

as all of these changes remain backwards compatible i have only bumped version to 9.6.0 rather than 10.0.0